### PR TITLE
add browserify support and prep for publishing on npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,16 @@
+/bower_components/
+/node_modules/
+npm-debug.log
+
+/.idea/
+.DS_Store
+
+/test/
+/src/
+/example/
+.editorconfig
+bower.json
+CONTRIBUTING.md
+Gruntfile.js
+karma.conf.js
+README.md

--- a/package.json
+++ b/package.json
@@ -47,5 +47,6 @@
   },
   "scripts": {
     "test": "grunt test"
-  }
+  },
+  "browser": "./dist/highcharts-ng.js"
 }


### PR DESCRIPTION
Make using this module with browserify easier.  If this module is published to npm in addition to bower,  .npmignore makes the node_modules footprint smaller.
